### PR TITLE
This should be the proper fix for podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD = $(CURDIR)/build
 KATAPREFIX = $(BUILD)/prefix
 KATACONFIG = $(KATAPREFIX)/etc/kata-containers/configuration.toml
-PODMAN_CONF = /usr/share/containers/containers.conf
+PODMAN_CONF = /etc/containers/containers.conf
 INITRD = $(KATAPREFIX)/var/cache/kata-containers/kata-containers-initrd.img
 OSBUILDER_SCRIPT = $(BUILD)/vfio-kata-osbuilder.sh
 AGENT_TREE = $(BUILD)/agent

--- a/podman-kata-vfio.conf.template
+++ b/podman-kata-vfio.conf.template
@@ -1,6 +1,6 @@
 
 # Added by scripts from kata-vfio-tools tree
 
-kata-vfio = [
+kata = [
 	"%KATARUNTIME%",
 ]


### PR DESCRIPTION
Podman supports three types of OCI currently, crun, runc and kata.

Podman uses the kata flag to pick the correct SELinux label to launch the container.

/usr/share/containers/containers.conf is owned by the distribution and should never be edited.  /etc/containers/containers.conf is for administrators and users to make customizations.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>